### PR TITLE
fix: sync release-please manifest and pyproject.toml versions to 0.1.4

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "aws-agentcore-a2a-proxy": "0.1.3"
+  "aws-agentcore-a2a-proxy": "0.1.4"
 }

--- a/aws-bedrock-a2a-proxy/pyproject.toml
+++ b/aws-bedrock-a2a-proxy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aws-agentcore-a2a-proxy"
-version = "0.1.3"
+version = "0.1.4"
 description = "A2A server for AWS Bedrock AgentCore agents"
 authors = [
     {name = "Dave Kerr"}


### PR DESCRIPTION
## Summary
• Sync release-please manifest from 0.1.3 to 0.1.4
• Sync pyproject.toml version from 0.1.3 to 0.1.4

## Context
Release-please created v0.1.4 release commit but the manifest and pyproject.toml were out of sync, causing build failures with PyPI "File already exists" error for 0.1.3.

## Test plan
- [x] Version consistency verified between manifest and pyproject.toml
- [x] This should allow the CI/CD pipeline to build and publish 0.1.4 correctly