### PR TITLE
fix: correct release-please config to update pyproject.toml versions

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "aws-agentcore-a2a-proxy": "0.1.4"
+  "aws-bedrock-a2a-proxy": "0.1.4"
 }

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,9 +1,10 @@
 {
-  "release-type": "python",
   "packages": {
-    "aws-agentcore-a2a-proxy": {
+    "aws-bedrock-a2a-proxy": {
       "release-type": "python",
-      "version-file": "aws-agentcore-a2a-proxy/pyproject.toml"
+      "extra-files": [
+        "aws-bedrock-a2a-proxy/pyproject.toml"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
• Fix package name mismatch in release-please config (aws-agentcore-a2a-proxy → aws-bedrock-a2a-proxy)
• Use `extra-files` instead of deprecated `version-file` for pyproject.toml updates
• Update manifest to match correct package name

## Problem
Release-please was only updating CHANGELOG.md but not pyproject.toml because:
1. Package name in config didn't match actual directory structure
2. Using deprecated `version-file` instead of modern `extra-files` approach
3. Manifest had mismatched package name

## Test plan
- [x] Configuration matches actual directory structure
- [x] Uses modern release-please `extra-files` approach
- [x] Manifest and config package names are aligned