### PR TITLE
fix: update package README title to use AgentCore consistently

### DIFF
--- a/aws-bedrock-a2a-proxy/README.md
+++ b/aws-bedrock-a2a-proxy/README.md
@@ -1,6 +1,6 @@
-# AWS Bedrock A2A Proxy
+# AWS AgentCore A2A Proxy
 
-A Python server that provides an A2A (Agent-to-Agent) proxy for AWS Bedrock AgentCore agents.
+A Python server that provides an A2A (Agent-to-Agent) proxy for AWS AgentCore agents.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Fix package README title from "AWS Bedrock A2A Proxy" to "AWS AgentCore A2A Proxy"
- Update description text to remove "Bedrock" reference

## Problem
The package README.md is used for the PyPI description, and it still showed "AWS Bedrock A2A Proxy" which is inconsistent with our naming.

## Changes
- Title: `# AWS Bedrock A2A Proxy` → `# AWS AgentCore A2A Proxy`
- Description: Remove "Bedrock" from the description text

This will update the PyPI description to be consistent with the project naming.