### PR TITLE
Improve AWS agent prompt with explicit tool usage instructions

### DIFF
--- a/demo/agents/aws-operator-agent/agent.py
+++ b/demo/agents/aws-operator-agent/agent.py
@@ -43,6 +43,15 @@ Use this tool for any AWS operations or queries to provide accurate, current inf
 - aws_command(command="sts get-caller-identity") - Get current AWS identity
 - aws_command(command="lambda list-functions") - List Lambda functions
 - aws_command(command="s3 ls s3://bucket-name") - List objects in specific bucket
+- aws_command(command="route53 list-hosted-zones") - List Route53 domains
+
+**TOOL USAGE:**
+- aws_command(command="s3 ls") - List S3 buckets
+- aws_command(command="route53 list-hosted-zones") - List Route53 domains  
+- aws_command(command="ec2 describe-instances") - List EC2 instances
+- aws_command(command="sts get-caller-identity") - Get current identity
+
+**IMPORTANT:** The command parameter should NOT include "aws" - just the service and action.
 
 **Example interactions:**
 


### PR DESCRIPTION
## Summary
- Add clear examples of aws_command tool usage to prevent execution errors
- Emphasize that command parameter should NOT include "aws" prefix
- Add route53 example based on recent user interaction issues

## Problem Solved
The AWS agent was requiring multiple attempts to execute commands correctly, showing:
1. Initial responses describing capabilities instead of executing commands
2. String concatenation errors when processing mixed data types
3. Users having to retry requests multiple times

## Changes
- Added explicit **TOOL USAGE** section with clear examples
- Emphasized the "no aws prefix" rule that was causing confusion
- Added route53 list-hosted-zones example for common use case
- Maintained all existing examples and structure

## Test Plan
- [x] Verify agent still loads and initializes correctly
- [ ] Test with route53 commands to ensure proper formatting
- [ ] Validate that tool usage instructions reduce retry attempts