### PR TITLE
Change port for aws-operator-agent to 8080 to work with AWS AgentCore

### DIFF
--- a/demo/agents/aws-operator-agent/agent.py
+++ b/demo/agents/aws-operator-agent/agent.py
@@ -237,5 +237,5 @@ def invoke(payload):
         return error_response
 
 if __name__ == "__main__":
-    # For local testing
-    app.run(port=9596)
+    # AWS AgentCore requires port 8080
+    app.run(port=8080)


### PR DESCRIPTION
AWS AgentCore requires port 8080, per [docs](https://docs.aws.amazon.com/marketplace/latest/userguide/bedrock-agentcore-runtime.html)